### PR TITLE
Add Staging SSH Smoke Test Workflow

### DIFF
--- a/.github/workflows/staging-ssh-smoke.yml
+++ b/.github/workflows/staging-ssh-smoke.yml
@@ -1,0 +1,75 @@
+name: Staging SSH Smoke Test
+on:
+    workflow_dispatch: {} # run manually from the Actions tab
+
+jobs:
+    ssh-smoke:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Print target (sanity)
+              run: |
+                  echo "Target host: ${{ secrets.STAGING_HOST }}"
+                  echo "Target user: ${{ secrets.STAGING_USER }}"
+
+            # Quick raw SSH check (helpful debug if the next step fails early)
+            - name: Raw SSH hello
+              env:
+                  HOST: ${{ secrets.STAGING_HOST }}
+                  USER: ${{ secrets.STAGING_USER }}
+                  KEY: ${{ secrets.STAGING_SSH_KEY }}
+              run: |
+                  set -e
+                  mkdir -p ~/.ssh
+                  echo "$KEY" > ~/.ssh/id_staging
+                  chmod 600 ~/.ssh/id_staging
+                  ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_staging "$USER@$HOST" 'echo "SSH OK: $(uname -a)"'
+
+            # Use the SSH action for a few deeper checks
+            - name: Deep checks (docker/caddy/opt path)
+              uses: appleboy/ssh-action@v1.0.3
+              with:
+                  host: ${{ secrets.STAGING_HOST }}
+                  username: ${{ secrets.STAGING_USER }}
+                  key: ${{ secrets.STAGING_SSH_KEY }}
+                  script_stop: true
+                  command_timeout: 30m
+                  script: |
+                      set -euo pipefail
+
+                      echo "[whoami]"; whoami
+                      echo "[hostname]"; hostname
+
+                      echo "[docker version]"; docker --version
+                      echo "[docker compose version]"; docker compose version || true
+                      echo "[docker service status]"
+                      if command -v systemctl >/dev/null 2>&1; then
+                        systemctl is-active docker
+                      else
+                        echo "systemd not available (OK on some distros)"
+                      fi
+
+                      echo "[caddy version]"; caddy version || true
+                      echo "[caddy service status]"
+                      if command -v systemctl >/dev/null 2>&1; then
+                        systemctl is-active caddy
+                      fi
+
+                      echo "[/opt layout]"
+                      ls -la /opt/campaign-staging || (echo "/opt missing — deploy-opt.yml probably not run" && exit 1)
+                      ls -la /opt/campaign-staging/stack
+
+                      echo "[compose ps]"
+                      cd /opt/campaign-staging/stack
+                      docker compose ps || true
+
+                      echo "[health scripts]"
+                      if [[ -f healthcheck.sh ]]; then
+                        echo "Running local health check samples (may fail if envs/images not yet set)"
+                        bash healthcheck.sh web || true
+                        bash healthcheck.sh gateway || true
+                        bash healthcheck.sh ml || true
+                      else
+                        echo "healthcheck.sh not found (OK if not deployed yet)"
+                      fi
+
+                      echo "✅ SSH smoke checks completed"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,94 @@
+name: "Staging (develop): Web"
+
+on:
+    push:
+        branches: [develop]
+
+env:
+    REGISTRY: ghcr.io
+    ORG: UIR-PFE-CampAIgn
+    SONAR_HOST_URL: https://sonarcloud.io
+
+concurrency:
+    group: staging-${{ github.repository }}
+    cancel-in-progress: true
+
+jobs:
+    test_and_sonar:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with: { node-version: "20" }
+
+            - uses: actions/cache@v4
+              with:
+                  path: ~/.npm
+                  key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+
+            - name: Install & Test (coverage)
+              run: |
+                  npm ci
+                  npm run test:ci   # must output coverage/lcov.info
+
+            - name: SonarCloud Scan
+              uses: SonarSource/sonarcloud-github-action@v2
+              env:
+                  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+                  SONAR_ORG: ${{ secrets.SONAR_ORG }}
+                  SONAR_PROJECT_KEY: ${{ secrets.SONAR_PROJECT_KEY }}
+                  SONAR_HOST_URL: ${{ env.SONAR_HOST_URL }}
+
+            - name: Wait for Quality Gate
+              uses: SonarSource/sonarqube-quality-gate-action@master
+              env:
+                  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+                  SONAR_HOST_URL: ${{ env.SONAR_HOST_URL }}
+
+    build_and_deploy:
+        needs: test_and_sonar
+        runs-on: ubuntu-latest
+        permissions: { contents: read, packages: write }
+        steps:
+            - uses: actions/checkout@v4
+            - uses: docker/setup-buildx-action@v3
+
+            - name: Login to GHCR
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Compute image tags
+              id: vars
+              run: |
+                  REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+                  echo "image=ghcr.io/${REPO_LOWER}" >> $GITHUB_OUTPUT
+                  echo "sha_short=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
+            - name: Build & Push
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  push: true
+                  tags: |
+                      ${{ steps.vars.outputs.image }}:develop
+                      ${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.sha_short }}
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
+
+            - name: Deploy web (targeted)
+              uses: appleboy/ssh-action@v1.0.3
+              with:
+                  host: ${{ secrets.STAGING_HOST }}
+                  username: ${{ secrets.STAGING_USER }}
+                  key: ${{ secrets.STAGING_SSH_KEY }}
+                  script_stop: true
+                  command_timeout: 30m
+                  script: |
+                      set -e
+                      cd /opt/campaign-staging/stack
+                      echo "WEB_TAG=${{ steps.vars.outputs.sha_short }}" | sudo tee .deploy_tags >/dev/null
+                      ./deploy.sh web


### PR DESCRIPTION
Introduce a new GitHub Actions workflow for performing SSH smoke tests on the staging environment. The workflow includes steps for verifying SSH connectivity, checking Docker and Caddy versions, and validating the deployment structure. This addition enhances the CI/CD process by ensuring that the staging environment is operational before further deployment actions.